### PR TITLE
TF Update (1.6.x) compatability (vpc flow log)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ data "aws_caller_identity" "current" {}
 data "aws_iam_policy_document" "kms" {
   count = module.this.enabled ? 1 : 0
 
-  source_json = var.kms_policy_source_json
+  source_policy_documents = var.kms_policy_source_json
 
   statement {
     sid    = "Enable Root User Permissions"

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ data "aws_caller_identity" "current" {}
 data "aws_iam_policy_document" "kms" {
   count = module.this.enabled ? 1 : 0
 
-  source_policy_documents = var.kms_policy_source_json
+  source_policy_documents = [var.kms_policy_source_json]
 
   statement {
     sid    = "Enable Root User Permissions"


### PR DESCRIPTION
We were testing with tf version 1.6.6 
In this version the   
`source_json = var.kms_policy_source_json`
changed for 
`source_policy_documents = [var.kms_policy_source_json]
`



